### PR TITLE
Build (almost) every language on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
       dotnet: 2.0.3
       mono: none
       before_install: cd csharp
+      script: dotnet build
 
     - name: "Clojure"
       language: clojure

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+matrix:
+  include:
+    - name: "C#"
+      language: csharp
+      before_install: cd csharp
+      dotnet: 2.0.3
+
+    - name: "Clojure"
+      language: clojure
+      before_install: cd clojure
+
+    - name: "Elm"
+      language: elm
+      elm: 0.17.1
+      before_install: cd elm
+      script: elm make --yes Main.elm
+
+    - name: "Elixir"
+      elixir: '1.7.0'
+      language: elixir
+      before_install: cd elixir
+      script: mix compile
+
+    - name: "Java"
+      language: java
+      before_install: cd java
+      script: ./gradlew test
+    
+    - name: "JavaScript"
+      language: node_js
+      node_js: "node"
+      before_install: cd js
+    
+    - name: "Kotlin"
+      language: kotlin
+      before_install: cd kotlin
+      script: ./gradlew test
+      
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ matrix:
   include:
     - name: "C#"
       language: csharp
-      before_install: cd csharp
       dotnet: 2.0.3
+      mono: none
+      before_install: cd csharp
 
     - name: "Clojure"
       language: clojure

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,13 +51,16 @@ matrix:
       language: php
       before_install: cd php
       php: "7.1.9"
+      before_script: composer dump-autoload
       script: php run.php
 
     - name: "Python"
       language: python
+      before_install: cd python
       python: "3.6"
       script: python main.py
 
     - name: "Ruby"
       language: ruby
+      before_install: cd ruby
       script: ruby client.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,3 +57,7 @@ matrix:
       language: python
       python: "3.6"
       script: python main.py
+
+    - name: "Ruby"
+      language: ruby
+      script: ruby client.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ matrix:
       language: node_js
       node_js: "node"
       before_install: cd js
+      script: npm start
     
     - name: "Kotlin"
       language: kotlin

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,3 +53,7 @@ matrix:
       php: "7.1.9"
       script: php run.php
 
+    - name: "Python"
+      language: python
+      python: "3.6"
+      script: python main.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,13 @@ matrix:
       before_install: cd elixir
       script: mix compile
 
+    - name: "F#"
+      language: csharp
+      mono: latest
+      before_install: cd fsharp
+      install: ./start.sh
+      script: fsharpi client.fsx
+
     - name: "Java"
       language: java
       before_install: cd java

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
     - name: "Elm"
       language: elm
       elm: 0.17.1
+      elm_test: 0.17.1
+      elm_format: 0.8.1
       before_install: cd elm
       script: elm make --yes Main.elm
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,5 +46,10 @@ matrix:
       language: kotlin
       before_install: cd kotlin
       script: ./gradlew test
-      
+     
+    - name: "PHP"
+      language: php
+      before_install: cd php
+      php: "7.1.9"
+      script: php run.php
 

--- a/js/package.json
+++ b/js/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "js",
+  "version": "1.0.0",
+  "description": "## running locally You need at least node 4.0 run `node main.js ../data/0.json`",
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\""
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/js/package.json
+++ b/js/package.json
@@ -4,6 +4,7 @@
   "description": "## running locally You need at least node 4.0 run `node main.js ../data/0.json`",
   "main": "main.js",
   "scripts": {
+    "start": "node main.js ../data/0.json",
     "test": "echo \"Error: no test specified\""
   },
   "author": "",


### PR DESCRIPTION
This adds a `.travis.yml` that will build every language (except C++) on Travis like [this job](https://travis-ci.org/rradczewski/playing_with_projections/builds/461988284).

First step towards keeping the individual projects maintained and up-to-date :+1: 