### PR TITLE
Elixir/add green ExUnit test to speed up test based approach

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
       script: elm make --yes Main.elm
 
     - name: "Elixir"
-      elixir: '1.7.0'
+      elixir: '1.7.4'
       language: elixir
       before_install: cd elixir
       script: mix test --trace

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       elixir: '1.7.0'
       language: elixir
       before_install: cd elixir
-      script: mix compile
+      script: mix test
 
     - name: "F#"
       language: csharp
@@ -36,18 +36,18 @@ matrix:
       language: java
       before_install: cd java
       script: ./gradlew test
-    
+
     - name: "JavaScript"
       language: node_js
       node_js: "node"
       before_install: cd js
       script: npm start
-    
+
     - name: "Kotlin"
       language: kotlin
       before_install: cd kotlin
       script: ./gradlew test
-     
+
     - name: "PHP"
       language: php
       before_install: cd php

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       elixir: '1.7.0'
       language: elixir
       before_install: cd elixir
-      script: mix test
+      script: mix test --trace
 
     - name: "F#"
       language: csharp

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -7,6 +7,7 @@ Secondly, in order to verify your solutions, you can choose to build tests for y
 Both approaches are supported by this code base and briefly described in the following sections.
 
 ## run with a local installation
+
 This assumes that you have Elixir setup on your machine, the minimum required version is Elixir v1.7
 
 From within this folder, install the required dependencies:
@@ -22,6 +23,7 @@ Or, run the production code and verify its output like so:
 `mix run -e QuizzyClient.main`
 
 ## run with docker-compose
+
 Provided you have docker installed and running in a reasonably recent version, you can use `docker-compose` to fetch the latest, official Elixir image and run the production code (QuizzyClient.main) like so:
 
 `docker-compose up`

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -1,8 +1,29 @@
 # QuizzyClient
 
-## run locally
-install dependencies: `mix deps.get`
-run client: `mix run -e QuizzyClient.main`
+There are two choices to be made. First, you have to decide whether you want to install Elixir and dependencies locally or whether you prefer to rely on a docker based setup, avoiding the need for any local installations in case you have docker already setup on your machine.
+
+Secondly, in order to verify your solutions, you can choose to build tests for your production code in the form of ExUnit tests. Alternatively, you can implement a verification technique (e.g. via `IO.inspect` or similar) in the production code directly.
+
+Both approaches are supported by this code base and briefly described in the following sections.
+
+## run with a local installation
+This assumes that you have Elixir setup on your machine, the minimum required version is Elixir v1.7
+
+From within this folder, install the required dependencies:
+
+`mix deps.get`
+
+Then, either go for the ExUnit test based approach and run
+
+`mix test`
+
+Or, run the production code and verify its output like so:
+
+`mix run -e QuizzyClient.main`
 
 ## run with docker-compose
+Provided you have docker installed and running in a reasonably recent version, you can use `docker-compose` to fetch the latest, official Elixir image and run the production code (QuizzyClient.main) like so:
+
 `docker-compose up`
+
+In case you want to switch to an ExUnit based approach, please see the comments in the `docker-compose.yml` file that resides next to this README in the same folder.

--- a/elixir/docker-compose.yml
+++ b/elixir/docker-compose.yml
@@ -11,4 +11,4 @@ services:
     # the client production code, please comment
     # the command above and uncomment the following
     # one instead.
-    # command: mix test
+    # command: mix test --trace

--- a/elixir/docker-compose.yml
+++ b/elixir/docker-compose.yml
@@ -6,3 +6,9 @@ services:
       - ..:/pwp
     working_dir: /pwp/elixir
     command: mix run -e QuizzyClient.main
+    # In case you want to use tests to verify
+    # your implementations, rather than running
+    # the client production code, please comment
+    # the command above and uncomment the following
+    # one instead.
+    # command: mix test

--- a/elixir/test/quizzy_client_test.exs
+++ b/elixir/test/quizzy_client_test.exs
@@ -10,8 +10,8 @@ defmodule QuizzyClientTest do
   Please note that in this test we make use of raw
   QuizzyClient features and also make use of a hard
   coded file path. You may find value in extracting
-  some of these aspects into your production code
-  eventually.
+  some of these aspects into functions in the production
+  code eventually.
   """
   test "that number of events in stream 0 is 4" do
     file = File.read!("../data/0.json")

--- a/elixir/test/quizzy_client_test.exs
+++ b/elixir/test/quizzy_client_test.exs
@@ -1,12 +1,25 @@
 defmodule QuizzyClientTest do
   @moduledoc """
   This is a working ExUnit test. It serves as a
-  placeholder in case you decide to write tests
-  for your solutions.
+  placeholder and starting point in case you decide
+  to derive your solutions guided by tests.
   """
   use ExUnit.Case
 
-  test "Elixir can add numbers" do
-    assert 42 == 40 + 2
+  @doc """
+  Please note that in this test we make use of raw
+  QuizzyClient features and also make use of a hard
+  coded file path. You may find value in extracting
+  some of these aspects into your production code
+  eventually.
+  """
+  test "that number of events in stream 0 is 4" do
+    file = File.read!("../data/0.json")
+
+    events = file
+    |> Poison.Parser.parse!(%{keys: :atoms})
+    |> Enum.map(&(QuizzyClient.parse(&1)))
+
+    assert length(events) == 4
   end
 end

--- a/elixir/test/quizzy_client_test.exs
+++ b/elixir/test/quizzy_client_test.exs
@@ -1,0 +1,12 @@
+defmodule QuizzyClientTest do
+  @moduledoc """
+  This is a working ExUnit test. It serves as a
+  placeholder in case you decide to write tests
+  for your solutions.
+  """
+  use ExUnit.Case
+
+  test "Elixir can add numbers" do
+    assert 42 == 40 + 2
+  end
+end


### PR DESCRIPTION
The changes in this PR add a green ExUnit test in order to help participants get started quickly in case they decide to write tests for their solutions, which in my view is a good idea to do in this workshop.

When we recently ran this workshop in Berlin, we noticed that, even though I have ample Elixir experience, I still needed to research a bit for the syntax that is used to write tests in Elixir and I hope this skeleton test will reduce the setup time for future participants.

Having this test in place also allows participants to verify that their setup is fully working.

As a possible follow-up PR, I am wondering whether to implement a real test for the most basic workshop problem. What do you think?
